### PR TITLE
add request on the leaderboard | fixed display score

### DIFF
--- a/packages/client/src/pages/Game/controllers/GameController.ts
+++ b/packages/client/src/pages/Game/controllers/GameController.ts
@@ -29,8 +29,7 @@ export class GameController {
     this.ctx = ctx
 
     this.isGameStart = false
-    //! Пока всегда getGameOver() будет true, нужно потом как то соединить это с уничтожением флага
-    this.isGameOver = true
+    this.isGameOver = false
     this.isGameLoaded = false
     this.isShowGameScore = false
     this.isLoadingLevel = false

--- a/packages/client/src/pages/Game/ui/GameOverMenu.ts
+++ b/packages/client/src/pages/Game/ui/GameOverMenu.ts
@@ -171,9 +171,9 @@ export class GameOverMenu {
       color: '#fff',
       width: 3,
       moveToX: this.startLineByX,
-      moveToY: this.lastY + 20,
+      moveToY: this.lastY === 0 ? 270 : this.lastY + 20,
       lineToX: this.endLineByX,
-      lineToY: this.lastY + 20,
+      lineToY: this.lastY === 0 ? 270 : this.lastY + 20,
     })
 
     // Измеряем measureText для того, чтобы смещать totalNumberOfDestroyedTanks если, кол-во танков превышвет 9
@@ -187,7 +187,7 @@ export class GameOverMenu {
       fontSize: 20,
       color: '#fff',
       x: 180 - textWidthScorePts,
-      y: this.lastY + 50,
+      y: this.lastY === 0 ? 305 : this.lastY + 55,
     })
   }
 }

--- a/packages/client/src/pages/Game/ui/Scene.ts
+++ b/packages/client/src/pages/Game/ui/Scene.ts
@@ -37,6 +37,8 @@ export class Scene {
   public explosions: { [k in string]: { coords: Coords; draw: () => void } } =
     {}
 
+  public totalScore: number
+
   constructor({
     ctx,
     sceneConfig,
@@ -48,6 +50,8 @@ export class Scene {
     this.ctx = ctx
     this.bullets = {}
     this.gameController = new GameController(ctx)
+
+    this.totalScore = 0
 
     const player = new Tank<'player'>({
       tankType: TankType.basic,
@@ -99,6 +103,16 @@ export class Scene {
 
   public render() {
     if (!this.sceneConfig.blocks.eagle) {
+      if (!this.gameController.isGameOver) {
+        const tanksArray = store.getState().tanks
+
+        this.totalScore = tanksArray.destroyedTanks.reduce(
+          (total: number, tank: { score: number }) => total + tank.score,
+          0
+        )
+
+        this.gameController.setGameOver(true, this.totalScore)
+      }
       this.gameController.drawGameOverMenu()
 
       return


### PR DESCRIPTION
- Добавил отправку запроса, когда уничтожается флаг

- Теперь в Leaderboard будет отображаться весь список пользователей, score будет рассчитываться относительно уничтоженных танков и передаваться в запрос.

 
![leaderboard](https://github.com/Ma1ve/BattleCity/assets/93385505/51afc36b-2767-44d5-8c89-80659a9d7500)

![31231233](https://github.com/Ma1ve/BattleCity/assets/93385505/794c3964-9dc2-43fe-9858-73301f6dc9e8)
